### PR TITLE
Feature/single plan on mobile show fix

### DIFF
--- a/src/assets/scss/App.scss
+++ b/src/assets/scss/App.scss
@@ -56,18 +56,12 @@
       margin: 15px 0;
       text-align: left;
 
-      h2, h3 {
-        display: inline-block;
-      }
-
       h2 {
         vertical-align: middle;
       }
 
       h3 {
         font-size: small;
-        margin-left: 15px;
-        background: #e0e0e0;
         padding: 3px;
         border-radius: 2px;
         vertical-align: sub;

--- a/src/assets/scss/App.scss
+++ b/src/assets/scss/App.scss
@@ -285,7 +285,8 @@
 
         .fs-packages {
           width: auto;
-          display: inline-block;
+          display: flex;
+          flex-direction: row;
           margin-bottom: 30px;
           border-top-right-radius: 10px;
           position: relative;

--- a/src/assets/scss/App.scss
+++ b/src/assets/scss/App.scss
@@ -269,6 +269,7 @@
           margin-top: -11px;
           cursor: pointer;
           font-size: 48px;
+          z-index: 1;
         }
 
         .fs-prev-package {

--- a/src/assets/scss/App.scss
+++ b/src/assets/scss/App.scss
@@ -1166,7 +1166,7 @@
       }
     }
 
-    @media only screen and (max-width: 400px) {
+    @media only screen and (max-width: 455px) {
       .fs-section--plans-and-pricing .fs-section--packages .fs-packages .fs-package {
         width: 100%;
       }
@@ -1195,6 +1195,15 @@
         .fs-section--testimonials .fs-testimonials-nav .fs-testimonials .fs-testimonial {
           width: auto;
         }
+      }
+    }
+  }
+
+  #fs_pricing_wrapper .fs-app-header {
+    @media only screen and (max-width: 445px) {
+      .fs-page-title h3{
+        margin-left: 0px;
+        margin-top: 10px;
       }
     }
   }

--- a/src/assets/scss/App.scss
+++ b/src/assets/scss/App.scss
@@ -271,6 +271,7 @@
 
         .fs-prev-package {
           visibility: hidden;
+          z-index: 2;
         }
 
         .fs-packages {

--- a/src/assets/scss/App.scss
+++ b/src/assets/scss/App.scss
@@ -717,7 +717,8 @@
       padding: 4em 4em 1.6em 4em;
 
       .fs-section-header {
-        color: #2da1d0;
+        margin-left: -30px;
+        margin-right: -30px;
       }
 
       .fs-testimonials-nav {
@@ -1015,7 +1016,7 @@
     z-index: 1000;
     zoom: 1;
     text-align: left;
-    display: block important;
+    display: block !important;
 
     .fs-modal-content-container {
       display: block;
@@ -1179,6 +1180,10 @@
 
       .fs-section--testimonials .fs-nav-pagination {
         display: none !important;
+      }
+
+      .fs-section > header h2 {
+        font-size: 1.5em;
       }
     }
 

--- a/src/assets/scss/App.scss
+++ b/src/assets/scss/App.scss
@@ -1176,6 +1176,10 @@
           margin-top: 0;
         }
       }
+
+      .fs-section--testimonials .fs-nav-pagination {
+        display: none !important;
+      }
     }
 
     @media only screen and (max-width: 455px) {

--- a/src/assets/scss/App.scss
+++ b/src/assets/scss/App.scss
@@ -443,6 +443,8 @@
 
               li {
                 font-size: 16px;
+                display: flex;
+                margin-bottom: 8px;
 
                 &:not(:first-child) {
                   margin-top: 8px;
@@ -457,6 +459,8 @@
                 .fs-feature-title {
                   margin: 0 5px;
                   color: #606060;
+                  max-width: 260px;
+                  overflow-wrap: break-word;
                 }
 
                 .fs-icon, .fs-tooltip {

--- a/src/assets/scss/App.scss
+++ b/src/assets/scss/App.scss
@@ -258,6 +258,11 @@
             right: 0;
             background: linear-gradient(to left, #cccccc96, transparent);
           }
+
+          &.fs-has-featured-plan:before,
+          &.fs-has-featured-plan:after {
+            top: 2.8em;
+          }
         }
 
         .fs-prev-package, .fs-next-package {
@@ -274,6 +279,10 @@
           z-index: 2;
         }
 
+        .fs-has-featured-plan .fs-packages {
+          margin-top: 2.8em;
+        }
+
         .fs-packages {
           width: auto;
           display: inline-block;
@@ -281,10 +290,6 @@
           border-top-right-radius: 10px;
           position: relative;
           transition: left 500ms ease,right 500ms ease;
-
-          &.fs-has-featured-plan {
-            margin-top: 2.8em;
-          }
 
           &:before {
             content: '';
@@ -1153,7 +1158,7 @@
 
         .fs-packages-tab {
           display: flex;
-          font-size: 24px;
+          font-size: 18px;
         }
 
         .fs-packages, .fs-package {
@@ -1164,6 +1169,10 @@
 
         .fs-packages-menu {
           display: flex;
+        }
+
+        .fs-has-featured-plan .fs-packages {
+          margin-top: 0;
         }
       }
     }

--- a/src/assets/scss/App.scss
+++ b/src/assets/scss/App.scss
@@ -246,8 +246,11 @@
             top: 0;
             bottom: 0;
             width: 60px;
-            z-index: 1;
             margin-bottom: 32px;
+          }
+
+          &:before {
+            z-index: 1;
           }
 
           &.fs-has-previous-plan:before {

--- a/src/assets/scss/App.scss
+++ b/src/assets/scss/App.scss
@@ -246,7 +246,6 @@
             top: 0;
             bottom: 0;
             width: 60px;
-            margin-top: 2.8em;
             z-index: 1;
             margin-bottom: 32px;
           }

--- a/src/assets/scss/App.scss
+++ b/src/assets/scss/App.scss
@@ -287,6 +287,8 @@
           width: auto;
           display: flex;
           flex-direction: row;
+          margin-left: auto;
+          margin-right: auto;
           margin-bottom: 30px;
           border-top-right-radius: 10px;
           position: relative;

--- a/src/components/FreemiusPricingMain.js
+++ b/src/components/FreemiusPricingMain.js
@@ -742,7 +742,7 @@ class FreemiusPricingMain extends Component {
                     {trialMessage}
                     <header className="fs-app-header">
                         <section className="fs-page-title">
-                            <h2>Plans and Pricing</h2>
+                            <h1>Plans and Pricing</h1>
                             <h3>Choose your plan and upgrade in minutes!</h3>
                         </section>
                         <section className="fs-plugin-title-and-logo">

--- a/src/components/packages/Package.js
+++ b/src/components/packages/Package.js
@@ -251,7 +251,7 @@ class Package extends Component {
         return <li key={planPackage.id} className={packageClassName}>
             <div className="fs-most-popular"><h4><strong>Most Popular</strong></h4></div>
             <div className="fs-package-content">
-                <h2 className="fs-plan-title"><strong>{planPackage.title}</strong></h2>
+                <h2 className="fs-plan-title"><strong>{isSinglePlan ? selectedPricing.sitesLabel() : planPackage.title}</strong></h2>
                 <h3 className="fs-plan-description">
                     <strong>{planPackage.description_lines}</strong>
                 </h3>

--- a/src/components/packages/PackagesContainer.js
+++ b/src/components/packages/PackagesContainer.js
@@ -77,7 +77,8 @@ class PackagesContainer extends Component {
                     cardWidth,
                     nextPrevPreviewWidth,
                     screenWidth,
-                    visibleCards;
+                    visibleCards,
+                    mobileSectionOffset;
 
                 let init = function () {
                     firstVisibleIndex           = 0;
@@ -92,10 +93,18 @@ class PackagesContainer extends Component {
                     defaultNextPrevPreviewWidth = 60;
                     cardMinWidth                = 315;
                     maxMobileScreenWidth        = 768;
+                    mobileSectionOffset         = 20;
                 };
 
+                const isMobileDevice = function () {
+                    const sectionComputedStyle = window.getComputedStyle($plansAndPricingSection),
+                        sectionWidth = parseFloat(sectionComputedStyle.width);
+
+                    return sectionWidth < (cardMinWidth * 2 - mobileSectionOffset);
+                }
+
                 let slide = function (selectedIndex, leftOffset) {
-                    let leftPos = (-1 * selectedIndex * cardWidth) + (leftOffset ? leftOffset : 0);
+                    let leftPos = (-1 * selectedIndex * cardWidth) + (leftOffset ? leftOffset : 0) - 1;
 
                     $packagesContainer.style.left = (leftPos + 'px');
                 };
@@ -105,7 +114,7 @@ class PackagesContainer extends Component {
 
                     let leftOffset = 0;
 
-                    if (screenWidth > maxMobileScreenWidth) {
+                    if ( ! isMobileDevice() && screenWidth > maxMobileScreenWidth) {
                         leftOffset = defaultNextPrevPreviewWidth;
 
                         if (firstVisibleIndex + visibleCards >= $packages.length) {
@@ -131,7 +140,7 @@ class PackagesContainer extends Component {
 
                     let leftOffset = 0;
 
-                    if (screenWidth > maxMobileScreenWidth) {
+                    if ( ! isMobileDevice() && screenWidth > maxMobileScreenWidth) {
                         if (firstVisibleIndex - 1 < 0) {
                             $prevPackage.style.visibility = 'hidden';
                             $packagesContainer.parentNode.classList.remove('fs-has-previous-plan');
@@ -159,7 +168,7 @@ class PackagesContainer extends Component {
                     let sectionComputedStyle = window.getComputedStyle($plansAndPricingSection),
                         sectionWidth         = parseFloat(sectionComputedStyle.width),
                         sectionLeftPos       = 0,
-                        isMobile             = (screenWidth <= maxMobileScreenWidth);
+                        isMobile             = (screenWidth <= maxMobileScreenWidth) || isMobileDevice();
 
                     nextPrevPreviewWidth = defaultNextPrevPreviewWidth;
 

--- a/src/components/packages/PackagesContainer.js
+++ b/src/components/packages/PackagesContainer.js
@@ -435,12 +435,12 @@ class PackagesContainer extends Component {
             }
         }
 
-        let packageComponents     = [],
-            isFirstPlanPackage    = true,
-            hasFeaturedPlan       = false,
-            mobileTabs            = [],
-            mobileDropdownOptions = [],
-            selectedPlanID        = this.context.selectedPlanID;
+        let packageComponents       = [],
+            isFirstPlanPackage      = true,
+            hasFeaturedPlan         = false,
+            mobileTabs              = [],
+            mobileDropdownOptions   = [],
+            selectedPlanOrPricingID = this.context.selectedPlanID;
 
         for (let visiblePlanPackage of visiblePlanPackages) {
             if (visiblePlanPackage.highlighted_features.length < maxHighlightedFeaturesCount) {
@@ -471,26 +471,28 @@ class PackagesContainer extends Component {
                 hasFeaturedPlan = true;
             }
 
-            if ( ! selectedPlanID && isFirstPlanPackage) {
-                selectedPlanID = visiblePlanPackage.id;
+            const visiblePlanOrPricingID = isSinglePlan ? visiblePlanPackage.pricing[0].id : visiblePlanPackage.id;
+
+            if ( ! selectedPlanOrPricingID && isFirstPlanPackage) {
+                selectedPlanOrPricingID = visiblePlanOrPricingID;
             }
 
             mobileTabs.push(
-                <li key={visiblePlanPackage.id} className={"fs-package-tab" + (visiblePlanPackage.id == selectedPlanID ? ' fs-package-tab--selected' : '')} data-plan-id={visiblePlanPackage.id} onClick={this.props.changePlanHandler}><a href="#">{visiblePlanPackage.title}</a></li>
+                <li key={visiblePlanOrPricingID} className={"fs-package-tab" + (visiblePlanOrPricingID == selectedPlanOrPricingID ? ' fs-package-tab--selected' : '')} data-plan-id={visiblePlanOrPricingID} onClick={this.props.changePlanHandler}><a href="#">{isSinglePlan ? visiblePlanPackage.pricing[0].sitesLabel(): visiblePlanPackage.title}</a></li>
             );
 
             mobileDropdownOptions.push(
                 <option
-                    key={visiblePlanPackage.id}
+                    key={visiblePlanOrPricingID}
                     className="fs-package-option"
-                    id={`fs_package_${visiblePlanPackage.id}_option`}
-                    value={visiblePlanPackage.id}
-                >{(visiblePlanPackage.id == selectedPlanID || isFirstPlanPackage ? 'Selected Plan: ' : '') + visiblePlanPackage.title}</option>
+                    id={`fs_package_${visiblePlanOrPricingID}_option`}
+                    value={visiblePlanOrPricingID}
+                >{(visiblePlanOrPricingID == selectedPlanOrPricingID || isFirstPlanPackage ? 'Selected Plan: ' : '') + visiblePlanPackage.title}</option>
             );
 
             packageComponents.push(
                 <Package
-                    key={isSinglePlan ? visiblePlanPackage.pricing[0].id : visiblePlanPackage.id}
+                    key={visiblePlanOrPricingID}
                     isFirstPlanPackage={isFirstPlanPackage}
                     installPlanLicensesCount={installPlanLicensesCount}
                     isSinglePlan={isSinglePlan}
@@ -514,7 +516,7 @@ class PackagesContainer extends Component {
         return <Fragment>
             <nav className="fs-prev-package"><Icon icon={['fas', 'chevron-left']}/></nav>
             <section className="fs-packages-nav">
-                {packageComponents.length > 3 && <select className="fs-packages-menu" onChange={this.props.changePlanHandler} value={selectedPlanID}>{mobileDropdownOptions}</select>}
+                {packageComponents.length > 3 && <select className="fs-packages-menu" onChange={this.props.changePlanHandler} value={selectedPlanOrPricingID}>{mobileDropdownOptions}</select>}
                 {packageComponents.length <= 3 && <ul className="fs-packages-tab">{mobileTabs}</ul>}
                 <ul className={"fs-packages" + (hasFeaturedPlan ? " fs-has-featured-plan" : "")}>{packageComponents}</ul>
             </section>

--- a/src/components/packages/PackagesContainer.js
+++ b/src/components/packages/PackagesContainer.js
@@ -524,10 +524,10 @@ class PackagesContainer extends Component {
 
         return <Fragment>
             <nav className="fs-prev-package"><Icon icon={['fas', 'chevron-left']}/></nav>
-            <section className="fs-packages-nav">
+            <section className={"fs-packages-nav" + (hasFeaturedPlan ? " fs-has-featured-plan" : "")}>
                 {packageComponents.length > 3 && <select className="fs-packages-menu" onChange={this.props.changePlanHandler} value={selectedPlanOrPricingID}>{mobileDropdownOptions}</select>}
                 {packageComponents.length <= 3 && <ul className="fs-packages-tab">{mobileTabs}</ul>}
-                <ul className={"fs-packages" + (hasFeaturedPlan ? " fs-has-featured-plan" : "")}>{packageComponents}</ul>
+                <ul className="fs-packages">{packageComponents}</ul>
             </section>
             <nav className="fs-next-package"><Icon icon={['fas', 'chevron-right']}/></nav>
         </Fragment>

--- a/src/components/testimonials/Testimonials.js
+++ b/src/components/testimonials/Testimonials.js
@@ -156,6 +156,13 @@ class Testimonials extends Component {
                     $testimonialsSection.classList.remove('ready');
 
                     sectionWidth = parseFloat(window.getComputedStyle($track).width);
+
+                    if (sectionWidth < cardMinWidth) {
+                        // In case of `sectionWidth` is below `cardMinWidth`, we should reduce `cardMinWidth`
+                        // by `sectionWidth` to set the width of the testimonial accordingly.
+                        cardMinWidth = sectionWidth;
+                    }
+
                     visibleCards = Math.min(maxVisibleReviews, Math.floor(sectionWidth / cardMinWidth));
                     cardWidth    = Math.floor(sectionWidth / visibleCards);
 
@@ -172,6 +179,10 @@ class Testimonials extends Component {
                         let $testimonial        = $testimonials[i],
                             $testimonialHeader  = $testimonial.querySelector('header'),
                             $testimonialSection = $testimonial.querySelector('section');
+
+                        // Since each height was fixed before, we should change it to the original height and then pick the maximum one.
+                        $testimonialHeader.style.height = '100%';
+                        $testimonialSection.style.height = '100%';
 
                         maxHeaderHeight  = Math.max(maxHeaderHeight, parseFloat(window.getComputedStyle($testimonialHeader).height));
                         maxContentHeight = Math.max(maxContentHeight, parseFloat(window.getComputedStyle($testimonialSection).height));


### PR DESCRIPTION
- [single-plan] [package] [bug-fix] In case of the customer has only one plan, we were relying on the plan name and the id to switch between packages. This is the issue, especially on the mobile side and so used the pricing ID and the number of sites to show the packages.