### PR TITLE
Fix race condition and UX janks in the packages slider

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+indent_style = tab
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/src/components/PackagesContainer/index.js
+++ b/src/components/PackagesContainer/index.js
@@ -275,11 +275,13 @@ class PackagesContainer extends Component {
       init();
       adjustPackages();
 
+      const handlePackagesMenuChange = evt => {
+        firstVisibleIndex = evt.target.selectedIndex - 1;
+        nextSlide();
+      };
+
       if ($packagesMenu) {
-        $packagesMenu.addEventListener('change', function (evt) {
-          firstVisibleIndex = evt.target.selectedIndex - 1;
-          nextSlide();
-        });
+        $packagesMenu.addEventListener('change', handlePackagesMenuChange);
       }
 
       const debouncedAdjustPackages = debounce(adjustPackages, 250);
@@ -289,21 +291,24 @@ class PackagesContainer extends Component {
       window.addEventListener('resize', debouncedAdjustPackages);
 
       return {
-        adjustPackages: function () {
-          init();
-          adjustPackages();
-        },
+        adjustPackages,
         clearEventListeners() {
           $nextPackage.removeEventListener('click', nextSlide);
           $prevPackage.removeEventListener('click', prevSlide);
           window.removeEventListener('resize', debouncedAdjustPackages);
+          if ($packagesMenu) {
+            $packagesMenu.removeEventListener(
+              'change',
+              handlePackagesMenuChange
+            );
+          }
         },
       };
     })();
   }
 
   componentDidUpdate() {
-    this.slider?.adjustPackages();
+    // this.slider?.adjustPackages();
   }
 
   componentWillUnmount() {

--- a/src/utils/debounce.js
+++ b/src/utils/debounce.js
@@ -1,0 +1,23 @@
+/**
+ * Returns a function, that, as long as it continues to be invoked, will not
+ * be triggered. The function will be called after it stops being called for
+ * N milliseconds. If `immediate` is passed, trigger the function on the
+ * leading edge, instead of the trailing.
+ *
+ * @link {https://davidwalsh.name/javascript-debounce-function}
+ */
+export function debounce(func, wait, immediate) {
+  let timeout;
+  return function () {
+    let context = this,
+      args = arguments;
+    let later = function () {
+      timeout = null;
+      if (!immediate) func.apply(context, args);
+    };
+    let callNow = immediate && !timeout;
+    clearTimeout(timeout);
+    timeout = setTimeout(later, wait);
+    if (callNow) func.apply(context, args);
+  };
+}


### PR DESCRIPTION
- [x] Use `Component` life-cycles instead of `setTimeout` for managing the slider.
- [x] Fix an issue when selecting a plan from the rightmost package will cause the slider to go to the left.
- [x] Document setup/customization/build instructions properly.